### PR TITLE
Codex: Add “Token Patterns and Configs” section [#P4-T2]

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -8,7 +8,7 @@
     - `README.md` “Chapters” list links to the new file, keeping language focused on learning objectives rather than product details.
     - Labels `phase:training`, `type:docs`, and `topic:workflow` applied to the tracking issue for this task.
 
-- [ ] Add “Token Patterns and Configs” section [#P4-T2]
+- [x] Add “Token Patterns and Configs” section [#P4-T2]
   - **Purpose:** Teach the reusable tokenization technique (`{PROJECT_NAME}`, `{ENTRYPOINT}`, `{CONFIG_PATH}`) that let discripper reuse prompts safely.
   - **Acceptance Criteria:**
     - Documentation (either a new doc or section within the case study) contrasts hard-coded values with tokenized variants using an annotated diff.


### PR DESCRIPTION
## Plan
- Add a tokenization section to the discripper case study with annotated examples, tables, and template guidance.
- Mark TASKS.md item #P4-T2 complete once the documentation meets the acceptance criteria.

## Changes
- 2 files changed, 31 insertions(+), 1 deletion(-)

## Tests
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e4845bba9483219e86357f71613634