### PR TITLE
[ADD] LOCAL_MODE.md — Sandbox mode guidance

### DIFF
--- a/.codex/instructions/LOCAL_MODE.md
+++ b/.codex/instructions/LOCAL_MODE.md
@@ -1,0 +1,14 @@
+# Local Sandbox Mode
+
+This repository operates in a Codex tutorial sandbox. Treat every task as a contained learning exercise focused solely on the `codex-hello-world` project.
+
+## Boundaries for Codex agents
+- Do **not** import, depend on, or clone external repositories (for example, `discripper`) while working in this sandbox. Any cross-project references are conceptual illustrations only.
+- Keep all changes limited to files that live inside this repository—primarily markdown, documentation, or configuration assets that support the lessons here.
+- Avoid introducing new runtime dependencies or cross-repo integrations. The goal is to practice local iteration, not multi-repo orchestration.
+
+## Workflow discipline
+- Follow the local workflow gates defined for this sandbox (e.g., `pip install -e .`, `ruff`, `pytest`). Passing these checks reinforces good hygiene even when changes affect only docs or configs.
+- When planning or documenting tasks, explicitly reference this file so future Codex agents remember the sandbox constraints.
+
+Staying within these boundaries keeps the tutorial environment predictable and self-contained for every run.

--- a/README.md
+++ b/README.md
@@ -19,5 +19,9 @@ Teach Codex Web workflow: start task → branch/PR → test → iterate → merg
 
 For more detail, explore the [/docs](docs) directory.
 
+## Operating Mode
+
+This repository runs in a guided sandbox for Codex training. See [`.codex/instructions/LOCAL_MODE.md`](.codex/instructions/LOCAL_MODE.md) for the boundaries that keep each exercise isolated and self-contained.
+
 ## How to iterate
 Codex tasks are one-shot: start a new task, issue, or review loop for each improvement pass. Read [Chapter 05](docs/05-agent-iteration-loop.md) to plan the right iteration pattern for your branch.


### PR DESCRIPTION
## Plan
- Capture the sandbox boundaries for Codex tutorial runs.
- Link the new guidance from the main README so future tasks discover it.

## Changes
- Add `.codex/instructions/LOCAL_MODE.md` to document local-only expectations and workflow gates.
- Reference the sandbox guidance from the README "Operating Mode" section.

## Tests
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68e486cab994832197730ca5d66b3016