### PR TITLE
[ADD] LOCAL_MODE.md — Sandbox mode guidance

### DIFF
--- a/.codex/instructions/LOCAL_MODE.md
+++ b/.codex/instructions/LOCAL_MODE.md
@@ -1,14 +1,14 @@
-# Local Sandbox Mode
+# Local Mode: Codex Tutorial Sandbox
 
-This repository operates in a Codex tutorial sandbox. Treat every task as a contained learning exercise focused solely on the `codex-hello-world` project.
+This repository, `codex-hello-world`, runs exclusively in a guided **tutorial / sandbox mode**. Every task inside this project is a teaching exercise that must remain self-contained.
 
-## Boundaries for Codex agents
-- Do **not** import, depend on, or clone external repositories (for example, `discripper`) while working in this sandbox. Any cross-project references are conceptual illustrations only.
-- Keep all changes limited to files that live inside this repository—primarily markdown, documentation, or configuration assets that support the lessons here.
-- Avoid introducing new runtime dependencies or cross-repo integrations. The goal is to practice local iteration, not multi-repo orchestration.
+## Sandbox Boundaries for Codex Agents
+- Operate **only** within this repository. Do not import, clone, or depend on any external projects (including case studies like `discripper`).
+- Treat any references to other products or services as conceptual examples—not integration targets.
+- Limit changes to local markdown, documentation, configuration, or other repo-scoped teaching assets. Avoid shipping product features or cross-repo infrastructure.
 
-## Workflow discipline
-- Follow the local workflow gates defined for this sandbox (e.g., `pip install -e .`, `ruff`, `pytest`). Passing these checks reinforces good hygiene even when changes affect only docs or configs.
-- When planning or documenting tasks, explicitly reference this file so future Codex agents remember the sandbox constraints.
+## Workflow Discipline
+- Follow the local gates for each run (`pip install -e .`, `ruff`, `pytest`, etc.) to reinforce clean iteration habits, even for documentation-focused tasks.
+- Reference this document in future task briefs and plans to keep the sandbox boundaries top-of-mind.
 
-Staying within these boundaries keeps the tutorial environment predictable and self-contained for every run.
+Staying within these guardrails preserves the isolated training environment that Codex needs for reliable, repeatable practice runs.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For more detail, explore the [/docs](docs) directory.
 
 ## Operating Mode
 
-This repository runs in a guided sandbox for Codex training. See [`.codex/instructions/LOCAL_MODE.md`](.codex/instructions/LOCAL_MODE.md) for the boundaries that keep each exercise isolated and self-contained.
+This repository runs in a guided sandbox for Codex training. Read [`.codex/instructions/LOCAL_MODE.md`](.codex/instructions/LOCAL_MODE.md) for the full local-mode guardrails that keep each exercise isolated and self-contained.
 
 ## How to iterate
 Codex tasks are one-shot: start a new task, issue, or review loop for each improvement pass. Read [Chapter 05](docs/05-agent-iteration-loop.md) to plan the right iteration pattern for your branch.


### PR DESCRIPTION
## Summary
- refresh the local-mode sandbox guidance for Codex tutorial runs
- point the operating-mode section of the README to the updated guidance document

## Testing
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68e4899bd31c8321839d88dc6f5ff4da