### PR TITLE
Codex: #P4-T7 Reinforce documentation discipline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ Teach Codex Web workflow: start task → branch/PR → test → iterate → merg
 6. Agent iteration loop — see [docs/05-agent-iteration-loop.md](docs/05-agent-iteration-loop.md)
 7. Read-Only QA Mode & Recovery — see [docs/06-read-only-mode.md](docs/06-read-only-mode.md)
 8. Codex Workflow: End-to-End — see [docs/07-end-to-end-workflow.md](docs/07-end-to-end-workflow.md)
-9. Discripper Workflow Case Study — see [docs/09-discripper-workflow-case-study.md](docs/09-discripper-workflow-case-study.md)
-10. CI Pragmatics Lessons — see [docs/10-ci-pragmatics-lessons.md](docs/10-ci-pragmatics-lessons.md)
-11. CLI UX Decisions — see [docs/11-cli-ux-decisions.md](docs/11-cli-ux-decisions.md)
-12. Contributing Tour — see [docs/08-contributing-tour.md](docs/08-contributing-tour.md)
+9. Contributing Tour — see [docs/08-contributing-tour.md](docs/08-contributing-tour.md)
+10. Discripper Workflow Case Study — see [docs/09-discripper-workflow-case-study.md](docs/09-discripper-workflow-case-study.md)
+11. CI Pragmatics Lessons — see [docs/10-ci-pragmatics-lessons.md](docs/10-ci-pragmatics-lessons.md)
+12. CLI UX Decisions — see [docs/11-cli-ux-decisions.md](docs/11-cli-ux-decisions.md)
+13. Documentation Discipline Checklist — see [docs/12-documentation-discipline.md](docs/12-documentation-discipline.md)
 
 For more detail, explore the [/docs](docs) directory.
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -48,7 +48,7 @@
     - Links to any CLI reference material in the repo so readers can experiment.
     - Task issue labeled `phase:training`, `type:docs`, `topic:workflow`.
 
-- [ ] Reinforce documentation discipline [#P4-T7]
+- [x] Reinforce documentation discipline [#P4-T7]
   - **Purpose:** Show that every task concludes with documentation updates and changelog alignment, mirroring discripper’s practice.
   - **Acceptance Criteria:**
     - Adds guidance on closing each task with doc updates, release notes, and changelog entries, with a sample checklist learners can reuse.

--- a/docs/12-documentation-discipline.md
+++ b/docs/12-documentation-discipline.md
@@ -1,0 +1,33 @@
+# Documentation Discipline Checklist
+
+The discripper program closed every task by updating the learner-facing record of work. This discipline kept Codex prompts, release notes, and changelog entries synchronized so follow-up automation never guessed at the source of truth. Use the following workflow to ensure each task finishes with a complete paper trail.
+
+## Task closure routine
+
+Adopt a repeatable end-of-task checklist so documentation, release notes, and changelog updates ship together:
+
+- [ ] Confirm user-facing docs reflect the behavior change (chapters, quickstarts, examples).
+- [ ] Add or update release notes with a one-line impact statement and links to the relevant docs.
+- [ ] Record the change in the project changelog with the same scope as the code diff.
+- [ ] Cross-link the task, PR, and docs so reviewers can navigate the full history.
+- [ ] Apply workflow labels (`phase:training`, `type:docs`, `topic:workflow`) to the tracking issue before closing it.
+- [ ] Capture any token or template updates (for example, snippets in [docs/02-task-template.md](02-task-template.md)) to keep future tasks aligned.
+
+Consider embedding the checklist above in `TASKS.md` entries or issue templates so every run has the reminders in-context.
+
+## Example PR summary snippet
+
+Tie code, docs, and changelog updates together in the PR body. A short summary like the following gives reviewers confidence that the task closed cleanly:
+
+```
+## Summary
+* Tightened validation for `codex run --title` to reject blank titles.
+* Documented the new error path in docs/11-cli-ux-decisions.md.
+* Logged the behavior change in CHANGELOG.md under "Unreleased".
+```
+
+Mentioning the docs and changelog directly in the summary is enough for release managers to trace the update without re-parsing the diff.
+
+## README and table-of-contents updates
+
+Whenever you add a new chapter under `/docs`, immediately update the README “Chapters” list (and any other table of contents) so learners can discover the file. Treat the README as the navigation surface: re-number chapters if necessary, keep the titles learner-focused, and link to the new file by path. Skipping this step creates drift between the published syllabus and the actual lessons, so make it part of the closure checklist before you mark a task complete.


### PR DESCRIPTION
## Plan
- Capture the task-closure checklist that covers docs, release notes, and changelog alignment.
- Update navigation surfaces so the new lesson is discoverable.
- Mark the checklist item complete in TASKS.md.

## Changes
 README.md                           |  9 +++++----
 TASKS.md                            |  2 +-
 docs/12-documentation-discipline.md | 33 +++++++++++++++++++++++++++++++++
 3 files changed, 39 insertions(+), 5 deletions(-)

## Tests
- `pip install -e .`
- `ruff check .`
- `pytest -q --cov=src --cov-fail-under=80`


------
https://chatgpt.com/codex/tasks/task_b_68e48f6676e08321b8f0a2194fe9adaa